### PR TITLE
fix a bug when no hypothesis is returned

### DIFF
--- a/lib/speech/audio_to_text.rb
+++ b/lib/speech/audio_to_text.rb
@@ -65,7 +65,7 @@ module Speech
           self.captured_json['status'] = data['status']
           self.captured_json['id'] = data['id']
           self.captured_json['hypotheses'] = data['hypotheses'].map {|ut| [ut['utterance'], ut['confidence']] } 
-          if data.key?('hypotheses') && ['hypotheses'].first
+          if data.key?('hypotheses') && data['hypotheses'].first
             self.best_match_text += " " + data['hypotheses'].first['utterance']
             self.score += data['hypotheses'].first['confidence']
             self.segments += 1


### PR DESCRIPTION
`{"status":5,"id":"b3224733ce27875cc6a02c91f4f161c5-1","hypotheses":[]}`

```
NoMethodError: undefined method `[]' for nil:NilClass
        from /usr/local/rvm/gems/ruby-1.9.3-p286/gems/speech2text-0.3.6/lib/speech/audio_to_text.rb
```
