### PR TITLE
add url support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source :rubygems
 
+gem 'uuid'
 gem 'curb'
 gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,11 @@ GEM
   specs:
     curb (0.8.1)
     json (1.5.1)
+    macaddr (1.6.1)
+      systemu (~> 2.5.0)
+    systemu (2.5.2)
+    uuid (2.3.7)
+      macaddr (~> 1.0)
 
 PLATFORMS
   ruby
@@ -10,3 +15,4 @@ PLATFORMS
 DEPENDENCIES
   curb
   json
+  uuid

--- a/bin/speech2text
+++ b/bin/speech2text
@@ -8,5 +8,4 @@ if ARGV[0].nil?
   exit(1)
 end
 
-captured_json = Speech::AudioToText.new(ARGV[0]).to_text
-puts captured_json.inspect
+Speech::AudioToText.new(ARGV[0]).to_text

--- a/bin/speech2text
+++ b/bin/speech2text
@@ -3,8 +3,8 @@
 
 require 'speech'
 
-if ARGV[0].nil? || !File.exist?(ARGV[0])
-  STDERR.puts "usage: #{$0} input.wav"
+if ARGV[0].nil? 
+  STDERR.puts "usage: #{$0} <input file|url>"
   exit(1)
 end
 

--- a/lib/speech.rb
+++ b/lib/speech.rb
@@ -1,6 +1,8 @@
 # -*- encoding: binary -*-
+
 require 'curb'
 require 'json'
+require 'uuid'
 
 module Speech; end
 

--- a/lib/speech/audio_splitter.rb
+++ b/lib/speech/audio_splitter.rb
@@ -9,7 +9,7 @@ module Speech
 
       def initialize(splitter, offset, duration)
         self.offset = offset
-        self.chunk = File.join(File.dirname(splitter.original_file), "chunk-" + File.basename(splitter.original_file).gsub(/\.(.*)$/, "-#{offset}" + '.\1'))
+        self.chunk = File.join("/tmp/" + UUID.generate + "-chunk-" + File.basename(splitter.original_file).gsub(/\.(.*)$/, "-#{offset}" + '.\1'))
         self.duration = duration
         self.splitter = splitter
         self.copied = false
@@ -72,7 +72,7 @@ module Speech
     end
 
     def initialize(file, chunk_size=5)
-      self.original_file = file
+      self.original_file = file      
       self.duration = AudioInspector.new(file).duration
       self.size = chunk_size
       self.chunks = []
@@ -84,7 +84,7 @@ module Speech
       last_chunk = ((self.duration.to_f % size) * 100).round / 100.0
       #puts "generate: #{full_chunks} chunks of #{size} seconds, last: #{last_chunk} seconds"
 
-      (full_chunks-1).times do|chunkid|
+      (full_chunks-1).times do |chunkid|
         if chunkid > 0
           chunks << AudioChunk.new(self, chunkid * self.size, self.size)
         else

--- a/lib/speech/audio_to_text.rb
+++ b/lib/speech/audio_to_text.rb
@@ -18,7 +18,7 @@ module Speech
 
     def to_text(max=2,lang="en-US")
       to_json(max,lang)
-      self.best_match_text
+      self.best_match_text if self.verbose
     end
 
     def to_json(max=2,lang="en-US")

--- a/lib/speech/audio_to_text.rb
+++ b/lib/speech/audio_to_text.rb
@@ -39,7 +39,6 @@ module Speech
     end
 
   protected
-
     def convert_chunk(easy, chunk, options={})
       puts "sending chunk of size #{chunk.duration}..." if self.verbose
       retrying = true
@@ -52,7 +51,6 @@ module Speech
         if self.verbose
           easy.on_progress {|dl_total, dl_now, ul_total, ul_now| printf("%.2f/%.2f\r", ul_now, ul_total); true }
         end
-        easy.on_complete {|easy| puts }
         easy.http_post
         if easy.response_code == 500
           puts "500 from google retry after 0.5 seconds" if self.verbose
@@ -69,6 +67,7 @@ module Speech
             self.best_match_text += " " + data['hypotheses'].first['utterance']
             self.score += data['hypotheses'].first['confidence']
             self.segments += 1
+            puts data['hypotheses'].first['utterance']
           end
           retrying = false
         end

--- a/lib/speech/audio_to_text.rb
+++ b/lib/speech/audio_to_text.rb
@@ -65,7 +65,7 @@ module Speech
           self.captured_json['status'] = data['status']
           self.captured_json['id'] = data['id']
           self.captured_json['hypotheses'] = data['hypotheses'].map {|ut| [ut['utterance'], ut['confidence']] } 
-          if data.key?('hypotheses') && data['hypotheses'].first
+          if data.key?('hypotheses') && !data['hypotheses'].nil? && data['hypotheses'].first
             self.best_match_text += " " + data['hypotheses'].first['utterance']
             self.score += data['hypotheses'].first['confidence']
             self.segments += 1

--- a/lib/speech/audio_to_text.rb
+++ b/lib/speech/audio_to_text.rb
@@ -65,7 +65,7 @@ module Speech
           self.captured_json['status'] = data['status']
           self.captured_json['id'] = data['id']
           self.captured_json['hypotheses'] = data['hypotheses'].map {|ut| [ut['utterance'], ut['confidence']] } 
-          if data.key?('hypotheses') && !data['hypotheses'].nil? && data['hypotheses'].first
+          if data.key?('hypotheses') && data['hypotheses'].first
             self.best_match_text += " " + data['hypotheses'].first['utterance']
             self.score += data['hypotheses'].first['confidence']
             self.segments += 1

--- a/speech2text.gemspec
+++ b/speech2text.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "curb"
   s.add_dependency "json"
+  s.add_dependency "uuid"
 end


### PR DESCRIPTION
I've added support for urls and suppressed the final output unless verbose. 
Now results can be displayed for each utterance as they are received. 
I realize this may be out of scope for this app, but it adds a nice touch if being used in a 
"real-time" fashion. With ffmpeg you can give it just about any type of file, or even live stream, and decode it on the fly.  
